### PR TITLE
Bug/squash

### DIFF
--- a/app.manifest
+++ b/app.manifest
@@ -59,7 +59,7 @@
                 "command": "/start_event",
                 "url": "https://five98-social-computing-bot.onrender.com/slack/commands",
                 "description": "Start an event and send prompts to all opted-in users",
-                "usage_hint": "[duration_in_minutes] (default: 60)",
+                "usage_hint": "[duration_in_days] (default: 60)",
                 "should_escape": false
             },
             {

--- a/database/models.py
+++ b/database/models.py
@@ -20,7 +20,7 @@ class User:
 class Event:
     id: int
     time_start: Optional[datetime]
-    duration_minutes: Optional[int]  # Changed from day_duration to duration_minutes
+    duration_days: Optional[int]  # Changed from day_duration to duration_days
     is_finalized: Optional[int] = 0  # 0 = not finalized, 1 = finalized
 
 

--- a/database/repos/events.py
+++ b/database/repos/events.py
@@ -22,32 +22,32 @@ def get_event_responses(event_id: int) -> List[str]:
 def is_event_over(event_id: int) -> bool:
     with get_db_cursor() as cur:
         cur.execute(
-            "SELECT time_start, duration_minutes FROM events WHERE id = %s",
+            "SELECT time_start, duration_days FROM events WHERE id = %s",
             (event_id,)
         )
         row = cur.fetchone()
         if not row:
             return False  # Event doesn't exist
 
-        time_start, duration_minutes = row
-        if not time_start or not duration_minutes:
+        time_start, duration_days = row
+        if not time_start or not duration_days:
             return False  # Event doesn't have start time or duration
 
-        # Calculate end time: start time + duration in minutes
-        end_time = time_start + timedelta(minutes=duration_minutes)
+        # Calculate end time: start time + duration in days (the stored value is treated as days)
+        end_time = time_start + timedelta(days=duration_days)
         current_time = datetime.now(
             time_start.tzinfo) if time_start.tzinfo else datetime.now()
 
         return current_time > end_time
 
 
-def create_event(time_start: Optional[datetime] = None, duration_minutes: int = 60) -> Literal["success", "database_error", "event_already_active"]:
+def create_event(time_start: Optional[datetime] = None, duration_days: int = 3) -> Literal["success", "database_error", "event_already_active"]:
     """
     Create a new event in the database.
 
     Args:
         time_start: When the event starts (defaults to now if None)
-        duration_minutes: How many minutes the event lasts (defaults to 60 = 1 hour)
+        duration_days: How many days the event lasts (defaults to 3)
 
     Returns:
         "success" if event was created successfully
@@ -61,17 +61,18 @@ def create_event(time_start: Optional[datetime] = None, duration_minutes: int = 
             # Check if an event is already active
             if get_active_event():
                 return "event_already_active"
+            # Store the provided number of days in the existing `duration_days` column
             cur.execute(
-                "INSERT INTO events (time_start, duration_minutes) VALUES (%s, %s) RETURNING id",
-                (time_start, duration_minutes)
+                "INSERT INTO events (time_start, duration_days) VALUES (%s, %s) RETURNING id",
+                (time_start, duration_days)
             )
             event_id = cur.fetchone()[0]
             cur.connection.commit()
 
             print(f"Event created successfully with ID: {event_id}")
             print(f"Start time: {time_start}")
-            print(f"Duration: {duration_minutes} minutes")
-            print(f"End time: {time_start + timedelta(minutes=duration_minutes)}")
+            print(f"Duration: {duration_days} days")
+            print(f"End time: {time_start + timedelta(days=duration_days)}")
 
             return "success"
     except Exception as e:
@@ -121,10 +122,21 @@ def delete_event(event_id: int) -> Literal["success", "event_not_found", "databa
 
 def get_active_event() -> Optional[Event]:
     with get_db_cursor() as cur:
-        cur.execute("SELECT id, time_start, duration_minutes, is_finalized FROM events WHERE time_start <= NOW() AND time_start + INTERVAL '1 minute' * duration_minutes >= NOW() ORDER BY time_start ASC LIMIT 1")
+        cur.execute("""
+            WITH non_finalized_events AS(
+                SELECT * FROM events WHERE is_finalized = 0
+            )
+
+            SELECT 
+                id, time_start, duration_days, is_finalized FROM non_finalized_events 
+            WHERE 
+                time_start + INTERVAL '1 day' * duration_days >= NOW() 
+            ORDER BY time_start 
+            ASC LIMIT 1
+        """)
         row = cur.fetchone()
         if row:
-            return Event(id=row[0], time_start=row[1], duration_minutes=row[2], is_finalized=row[3])
+            return Event(id=row[0], time_start=row[1], duration_days=row[2], is_finalized=row[3])
         return None
 
 
@@ -138,14 +150,14 @@ def get_unfinalized_ended_events() -> List[Event]:
     """
     with get_db_cursor() as cur:
         cur.execute("""
-            SELECT id, time_start, duration_minutes, is_finalized 
+            SELECT id, time_start, duration_days, is_finalized 
             FROM events 
             WHERE is_finalized = 0
-            AND time_start + INTERVAL '1 minute' * duration_minutes < NOW()
+            AND time_start + INTERVAL '1 day' * duration_days < NOW()
             ORDER BY time_start ASC
         """)
         rows = cur.fetchall()
-        return [Event(id=row[0], time_start=row[1], duration_minutes=row[2], is_finalized=row[3]) for row in rows]
+        return [Event(id=row[0], time_start=row[1], duration_days=row[2], is_finalized=row[3]) for row in rows]
 
 
 def mark_event_finalized(event_id: int) -> Literal["success", "event_not_found", "database_error"]:
@@ -182,16 +194,19 @@ def mark_event_finalized(event_id: int) -> Literal["success", "event_not_found",
 
 def delete_all_events():
     with get_db_cursor() as cur:
-        cur.execute("DELETE FROM events CASCADE")
-        # @TODO reset event number back to 1 if you delete all of the events
+        # remove event messaging first to avoid FK issues, then events
+        cur.execute("DELETE FROM event_messaging")
+        cur.execute("DELETE FROM events")
         cur.connection.commit()
-        return "success"
+    return "success"
+ 
 
-
-def add_message_to_event(event_id: int, sys_message_id: int) -> None:
+def add_message_to_event(event_id: int, sys_message_id: int):
+    # minimal implementation: associate a system message with an event
     with get_db_cursor() as cur:
         cur.execute(
             "INSERT INTO event_messaging (event_id, sys_message_id) VALUES (%s, %s) ON CONFLICT DO NOTHING",
             (event_id, sys_message_id),
         )
         cur.connection.commit()
+    return "success"

--- a/routes/commands.py
+++ b/routes/commands.py
@@ -154,12 +154,20 @@ def slash():
     # ---------- /opt_in ----------
     if command == "/opt_in":
         slack_id = request.form.get("user_id")
+        print(f"slack_id: {slack_id}")
+        print(slack_id)
         user = users.get_user_by_slack_id(slack_id)
         if user:
-            return jsonify({"text": "✅ You’re already opted in!"})
+            return jsonify({"text": f"🎉 You’ve successfully opted in!\n "
+            "Terms of Service: By opting-in, you are agreeing to participating in a term-project for Social Computing, "
+            "CSE 598-012. We only collect resposnes you provide, which are used with LLMs to generate new channels. If at any point you wish to not "
+            "participate, please use the command '/opt_out'. To review this message, simply type '/opt_in'. Thank you for joining us!"})
         # User not found → create
         user = users.create_user(slack_id)
-        return jsonify({"text": f"🎉 You’ve successfully opted in! (UUID: {user.id})"})
+        return jsonify({"text": f"🎉 You’ve successfully opted in!\n "
+            "Terms of Service: By opting-in, you are agreeing to participating in a term-project for Social Computing, "
+            "CSE 598-012. We only collect resposnes you provide, which are used with LLMs to generate new channels. If at any point you wish to not "
+            "participate, please use the command '/opt_out'. To review this message, simply type '/opt_in'. Thank you for joining us!"})
 
     if command == "/generate_prompt":
         prompt_schema = {

--- a/routes/commands.py
+++ b/routes/commands.py
@@ -33,9 +33,11 @@ def slash():
     command = request.form.get("command", "")
     user_id = request.form.get("user_id", "")
     channel_id = request.form.get("channel_id", "")
-    enterprise_name = request.form.get("enterprise_name", "")
+    enterprise_name = request.form.get("enterprise_name", None) or request.form.get("team_domain", "default")
     text = (request.form.get("text") or "").strip()
     response_url = request.form.get("response_url")
+
+    print(f"FORM NAME:\n{str(request.form)}\n----------")
 
     if not response_url:
         return jsonify({"response_type": "ephemeral", "text": "Missing response_url from Slack."}), 200
@@ -250,6 +252,7 @@ def slash():
         return "", 200
 
     if command == "/set_enterprise_description":
+        print(f"ENTERPRISE NAME: {enterprise_name}")
         if user_id and not users.is_user_admin(user_id):
             return jsonify({
                 "response_type": "ephemeral",


### PR DESCRIPTION
Fixes:
 - Opt_in throwing dispatch error
   - Fix: Remove Slack ID from message, the return type of new users does not return a User object
   - Added ToS so users are aware of our collection policy
 - Converted minutes back to time
   - Fix: Undo minute logic in DB and commands file
   - Needs review from @rayhanrashed in case I missed any hidden logic

TODO:
 [] We should utilize `is_finalized` when ending events. This variable is available but not yet functionally active. If a user finalizes an event, all we need to do is set flag.